### PR TITLE
Add the ability to getBalance an ERC20 token on different chains

### DIFF
--- a/netlify/functions/getBalance.js
+++ b/netlify/functions/getBalance.js
@@ -1,0 +1,92 @@
+//
+// gets balance from an ERC20 contract
+//
+// expects the following payload:
+// payload = { chain: number, addressToCheck: string [, token: string]}
+//
+
+const axios = require("axios");
+const ethers = require("ethers");
+
+const MORALIS_API_KEY = process.env.MORALIS_API_KEY; // pull key from Netlify
+const MORALIS_BASE = "https://deep-index.moralis.io/api/v2/"
+
+// useful addresses
+// const PINT_BSC_TEST = "0x6DbcC67369c9F3D1CB75B07aAC421c6E9700C62d"
+// const PINT_AVAX_FUJI = "0xeC104B9cA585c73D38b87397Cd3B34417Be0EDf6"
+
+exports.handler = async event => {
+
+  // require a POST
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: 'Method Not Allowed, Must POST', headers: { "Allow": "POST" } }
+  }
+
+  // get the payload
+  const data = JSON.parse(event.body)
+
+  // for now we require the payload to include an address to check the balance of, and a chain
+  if (!data.addressToCheck || !data.chain) {
+    return { statusCode: 422, body: '"addressToCheck" and "chain" are required parameters' }
+  }
+
+  const chain = strToHex(data.chain); // moralis expects hexed chain IDs (strings), not numbers
+  const erc20 = data.token || ""; // if erc20 isn't passed, Moralis will return all balances
+  const addressToCheck = data.addressToCheck;
+
+  // build the API URL
+  const MORALIS_ENDPOINT = `${addressToCheck}/erc20`
+  const MORALIS_PARAMS = `?chain=${chain}&token_addresses=${erc20}`
+  const URL = MORALIS_BASE + MORALIS_ENDPOINT + MORALIS_PARAMS;
+
+  const REQ_OPTS = {
+    url: URL,
+    method: "get",
+    headers: {
+      accept: "application/json",
+      "X-API-Key": MORALIS_API_KEY
+    }
+  }
+
+  let response;
+  try {
+    response = await axios.get(URL, REQ_OPTS);
+
+    // DEBUG:
+    // console.log(event.queryStringParameters);
+    // console.log('response:', response)
+    // console.log('response.data:', response.data);
+    return {
+       statusCode: response.status,
+       body: JSON.stringify(response.data),
+      };
+
+  } catch (e) {
+    // DEBUG:
+    // console.error("error while getting data...", e)
+    if(e.code === "ERR_HTTP_INVALID_HEADER_VALUE"){
+      e = "\nPlease set MORALIS_API_KEY in Netlify Environment Variables"
+    };
+
+    return {
+      statusCode: 500,
+      body: "Error while fetching data from moralis: " + e,
+    }
+  }
+}
+
+//
+// begin helper functions
+//
+
+function strToHex(string){
+  try {
+    return ethers.utils.hexlify(string)
+  } catch (e) {
+
+    return {
+      statusCode: 500,
+      body: "Error while hexlifying data:" + e,
+    }
+  }
+}

--- a/netlify/functions/getERC20Metadata.js
+++ b/netlify/functions/getERC20Metadata.js
@@ -1,0 +1,42 @@
+//
+// gets metadata from an ERC20 contract (Name, Symbol, etc...)
+//
+const axios = require('axios');
+
+const MORALIS_API_KEY = process.env.MORALIS_API_KEY; // pull key from Netlify
+
+const MORALIS_BASE = "https://deep-index.moralis.io/api/v2/"
+const MORALIS_ENDPOINT = "erc20/metadata"
+const MORALIS_PARAMS = "?chain=bsc%20testnet&addresses=0x6DbcC67369c9F3D1CB75B07aAC421c6E9700C62d"
+
+const URL = MORALIS_BASE + MORALIS_ENDPOINT + MORALIS_PARAMS;
+
+const REQ_OPTS = {
+  url: URL,
+  method: "get",
+  headers: {
+    accept: "application/json",
+    "X-API-Key": MORALIS_API_KEY
+  }
+}
+
+exports.handler = async event => {
+  let response;
+  try {
+    response = await axios.get(URL, REQ_OPTS);
+    // DEBUG:
+    // console.log('response.data:', response.data);
+    return {
+       statusCode: response.status,
+       body: JSON.stringify(response.data),
+      };
+
+  } catch (e) {
+    // DEBUG:
+    // console.error("error while getting data...")
+    return {
+      statusCode: 500,
+      body: "Error while fetching data from moralis: " + e,
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "pub-finance-site",
       "version": "0.1.0",
       "dependencies": {
         "@craco/craco": "^6.1.1",
         "@testing-library/jest-dom": "^5.11.10",
         "@testing-library/react": "^11.2.6",
         "@testing-library/user-event": "^12.8.3",
+        "axios": "^0.26.1",
         "bignumber.js": "^9.0.1",
         "chart.js": "^3.1.1",
         "ethers": "^5.1.4",
@@ -4913,6 +4915,14 @@
       "integrity": "sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/axobject-query": {
@@ -9919,9 +9929,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "funding": [
         {
           "type": "individual",
@@ -28278,6 +28288,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.4.tgz",
       "integrity": "sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig=="
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -32295,9 +32313,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
+    "axios": "^0.26.1",
     "bignumber.js": "^9.0.1",
     "chart.js": "^3.1.1",
     "ethers": "^5.1.4",


### PR DESCRIPTION
MORALIS_API_KEY must be specified in the Netlify environment variables, this key can be retrieved from the moralis.io dashboard after setting up an account.

A server in Moralis will then need to be created for each chain you wish to query.

Example calls:

# GetBalance

BSC Testnet:
`$ netlify functions:invoke --payload '{"chain": 97,"addressToCheck": "your_address", "token": "0x6DbcC67369c9F3D1CB75B07aAC421c6E9700C62d"}' getBalance`

Avax Fuji:
`$ netlify functions:invoke --payload '{"chain": 43113,"addressToCheck": "your_address", "token": "0xeC104B9cA585c73D38b87397Cd3B34417Be0EDf6"}' getBalance`

It's also possible to specify no token address and receive all balances:

`$ netlify functions:invoke --payload '{"chain": 43113,"addressToCheck": "your_address"}' getBalance`

# GetERC20Metadata

`$ netlify functions:invoke getERC20Metadata`